### PR TITLE
fix: Remove knative build spec after all

### DIFF
--- a/pkg/config/jobs.go
+++ b/pkg/config/jobs.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/jenkins-x/go-scm/scm"
-	buildv1alpha1 "github.com/knative/build/pkg/apis/build/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -105,8 +104,6 @@ type JobBase struct {
 	SourcePath string `json:"-"`
 	// Spec is the Kubernetes pod spec used if Agent is kubernetes.
 	Spec *v1.PodSpec `json:"spec,omitempty"`
-	// BuildSpec is the Knative build spec used if Agent is knative-build.
-	BuildSpec *buildv1alpha1.BuildSpec `json:"build_spec,omitempty"`
 
 	UtilityConfig
 }


### PR DESCRIPTION
We don't actually use it, and it causes problems bumping knative pkg
dependencies downstream.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>